### PR TITLE
Set ERExtensions as the EOModelGroup class delegate

### DIFF
--- a/src/main/java/com/wounit/rules/AbstractEditingContextRule.java
+++ b/src/main/java/com/wounit/rules/AbstractEditingContextRule.java
@@ -46,6 +46,12 @@ import er.extensions.eof.ERXEC;
  * @since 1.0
  */
 public abstract class AbstractEditingContextRule extends ERXEC implements MethodRule {
+
+	// Lazy initialization of singleton instance of ERXExtensions
+	private static class SINGLETONS {
+		static ERXExtensions exrExtensions = new ERXExtensions();
+	}
+
     /**
      * This facade creates enterprise objects and inserts them into the
      * specified editing context.
@@ -89,6 +95,9 @@ public abstract class AbstractEditingContextRule extends ERXEC implements Method
 	System.setProperty("NSProjectBundleEnabled", "true");
 
 	System.setProperty("NSBundleFactories", "(" + WOUnitBundleFactory.class.getName() + ")");
+
+	// Simulate what ERExtensions does
+	EOModelGroup.setClassDelegate(SINGLETONS.exrExtensions);
 
 	for (String modelName : modelNames) {
 	    loadModel(modelName);


### PR DESCRIPTION
When ERXExtensions (principal class) loads in a Wonder app, it sets itself as the class delegate for EOModelGroup such that EOModelGroup.defaultGroup() method is delegated to ERXExtensions. This in turn will enable the use of Extended Prototypes.

Along with this change, properties need to be set before the model loads for a test:
er.extensions.ERXModelGroup.modelClassName = com.webobjects.eoaccess.ERXModel
er.extensions.ERXModel.useExtendedPrototypes = true
er.extensions.ERXModelGroup.flattenPrototypes = false

Without this patch, entities depending on the use of extended prototypes will not be initialized properly.

Henrique, if you think this should be implemented some other way, then by all means do so.
