### PR TITLE
Added support for entities that have a primary key of type Long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib
 target
 .classpath
 .project
+.idea/

--- a/src/main/java/com/wounit/rules/MockEditingContext.java
+++ b/src/main/java/com/wounit/rules/MockEditingContext.java
@@ -36,6 +36,7 @@ import com.webobjects.foundation.NSMutableArray;
 import com.webobjects.foundation.NSRange;
 import com.wounit.annotations.Dummy;
 
+import er.extensions.eof.ERXModelGroup;
 import er.extensions.eof.ERXQ;
 import er.extensions.eof.ERXS;
 import er.extensions.foundation.ERXArrayUtilities;
@@ -99,7 +100,7 @@ public class MockEditingContext extends AbstractEditingContextRule {
     /**
      * A counter for fake global IDs.
      */
-    private int globalFakeId = 0;
+    private long globalFakeId = 0;
 
     /**
      * An array of objects whose changes must be ignored during the test cycle.
@@ -151,8 +152,12 @@ public class MockEditingContext extends AbstractEditingContextRule {
 
     private EOGlobalID createPermanentGlobalFakeId(String entityName) {
 	globalFakeId++;
+	final EOEntity entity =ERXModelGroup.defaultGroup().entityNamed(entityName);
+	if (entity.primaryKeyAttributes().size() == 1 && entity.primaryKeyAttributes().get(0).valueTypeClassName().equals(Long.class.getName())){
+		return new _EOIntegralKeyGlobalID(entityName, globalFakeId);
+	}
 
-	return new _EOIntegralKeyGlobalID(entityName, globalFakeId);
+	return new _EOIntegralKeyGlobalID(entityName, (int)globalFakeId);
     }
 
     /**
@@ -284,7 +289,7 @@ public class MockEditingContext extends AbstractEditingContextRule {
      * <code>EOEditingContext<code> to not call the super behavior for objects
      * registered with {@link #insertSavedObject(EOEnterpriseObject)} or {@link #createSavedObject(Class)}.
      * 
-     * @param anObject
+     * @param object
      *            the object whose state is to be recorded
      * 
      * @see er.extensions.eof.ERXEC#objectWillChange(java.lang.Object)

--- a/src/test/java/com/wounit/model/LongPKEntity.java
+++ b/src/test/java/com/wounit/model/LongPKEntity.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2009 hprange <hprange@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.wounit.model;
+
+import org.apache.log4j.Logger;
+
+public class LongPKEntity extends _LongPKEntity {
+  private static Logger log = Logger.getLogger(LongPKEntity.class);
+}

--- a/src/test/java/com/wounit/model/_LongPKEntity.java
+++ b/src/test/java/com/wounit/model/_LongPKEntity.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2009 hprange <hprange@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+// $LastChangedRevision$ DO NOT EDIT.  Make changes to LongPKEntity.java instead.
+package com.wounit.model;
+
+import com.webobjects.eoaccess.*;
+import com.webobjects.eocontrol.*;
+import com.webobjects.foundation.*;
+import java.math.*;
+import java.util.*;
+import org.apache.log4j.Logger;
+
+@SuppressWarnings("all")
+public abstract class _LongPKEntity extends er.extensions.eof.ERXGenericRecord {
+	public static final String ENTITY_NAME = "LongPKEntity";
+
+	// Attributes
+	public static final String BAR_KEY = "bar";
+	public static final String TYPE_KEY = "type";
+
+	// Relationships
+
+  private static Logger LOG = Logger.getLogger(_LongPKEntity.class);
+
+  public LongPKEntity localInstanceIn(EOEditingContext editingContext) {
+    LongPKEntity localInstance = (LongPKEntity)EOUtilities.localInstanceOfObject(editingContext, this);
+    if (localInstance == null) {
+      throw new IllegalStateException("You attempted to localInstance " + this + ", which has not yet committed.");
+    }
+    return localInstance;
+  }
+
+  public String bar() {
+    return (String) storedValueForKey("bar");
+  }
+
+  public void setBar(String value) {
+    if (_LongPKEntity.LOG.isDebugEnabled()) {
+    	_LongPKEntity.LOG.debug( "updating bar from " + bar() + " to " + value);
+    }
+    takeStoredValueForKey(value, "bar");
+  }
+
+  public Integer type() {
+    return (Integer) storedValueForKey("type");
+  }
+
+  public void setType(Integer value) {
+    if (_LongPKEntity.LOG.isDebugEnabled()) {
+    	_LongPKEntity.LOG.debug( "updating type from " + type() + " to " + value);
+    }
+    takeStoredValueForKey(value, "type");
+  }
+
+
+  public static LongPKEntity createLongPKEntity(EOEditingContext editingContext) {
+    LongPKEntity eo = (LongPKEntity) EOUtilities.createAndInsertInstance(editingContext, _LongPKEntity.ENTITY_NAME);    
+    return eo;
+  }
+
+  public static NSArray<LongPKEntity> fetchAllLongPKEntities(EOEditingContext editingContext) {
+    return _LongPKEntity.fetchAllLongPKEntities(editingContext, null);
+  }
+
+  public static NSArray<LongPKEntity> fetchAllLongPKEntities(EOEditingContext editingContext, NSArray<EOSortOrdering> sortOrderings) {
+    return _LongPKEntity.fetchLongPKEntities(editingContext, null, sortOrderings);
+  }
+
+  public static NSArray<LongPKEntity> fetchLongPKEntities(EOEditingContext editingContext, EOQualifier qualifier, NSArray<EOSortOrdering> sortOrderings) {
+    EOFetchSpecification fetchSpec = new EOFetchSpecification(_LongPKEntity.ENTITY_NAME, qualifier, sortOrderings);
+    fetchSpec.setIsDeep(true);
+    NSArray<LongPKEntity> eoObjects = (NSArray<LongPKEntity>)editingContext.objectsWithFetchSpecification(fetchSpec);
+    return eoObjects;
+  }
+
+  public static LongPKEntity fetchLongPKEntity(EOEditingContext editingContext, String keyName, Object value) {
+    return _LongPKEntity.fetchLongPKEntity(editingContext, new EOKeyValueQualifier(keyName, EOQualifier.QualifierOperatorEqual, value));
+  }
+
+  public static LongPKEntity fetchLongPKEntity(EOEditingContext editingContext, EOQualifier qualifier) {
+    NSArray<LongPKEntity> eoObjects = _LongPKEntity.fetchLongPKEntities(editingContext, qualifier, null);
+    LongPKEntity eoObject;
+    int count = eoObjects.count();
+    if (count == 0) {
+      eoObject = null;
+    }
+    else if (count == 1) {
+      eoObject = (LongPKEntity)eoObjects.objectAtIndex(0);
+    }
+    else {
+      throw new IllegalStateException("There was more than one LongPKEntity that matched the qualifier '" + qualifier + "'.");
+    }
+    return eoObject;
+  }
+
+  public static LongPKEntity fetchRequiredLongPKEntity(EOEditingContext editingContext, String keyName, Object value) {
+    return _LongPKEntity.fetchRequiredLongPKEntity(editingContext, new EOKeyValueQualifier(keyName, EOQualifier.QualifierOperatorEqual, value));
+  }
+
+  public static LongPKEntity fetchRequiredLongPKEntity(EOEditingContext editingContext, EOQualifier qualifier) {
+    LongPKEntity eoObject = _LongPKEntity.fetchLongPKEntity(editingContext, qualifier);
+    if (eoObject == null) {
+      throw new NoSuchElementException("There was no LongPKEntity that matched the qualifier '" + qualifier + "'.");
+    }
+    return eoObject;
+  }
+
+  public static LongPKEntity localInstanceIn(EOEditingContext editingContext, LongPKEntity eo) {
+    LongPKEntity localInstance = (eo == null) ? null : (LongPKEntity)EOUtilities.localInstanceOfObject(editingContext, eo);
+    if (localInstance == null && eo != null) {
+      throw new IllegalStateException("You attempted to localInstance " + eo + ", which has not yet committed.");
+    }
+    return localInstance;
+  }
+}

--- a/src/test/java/com/wounit/rules/TestMockEditingContext.java
+++ b/src/test/java/com/wounit/rules/TestMockEditingContext.java
@@ -48,6 +48,7 @@ import com.webobjects.foundation.NSArray;
 import com.wounit.model.DifferentClassNameForEntity;
 import com.wounit.model.FooEntity;
 import com.wounit.model.FooEntityWithRequiredField;
+import com.wounit.model.LongPKEntity;
 import com.wounit.model.StubEntity;
 import com.wounit.model.SubFooEntity;
 import com.wounit.stubs.StubTestCase;
@@ -558,6 +559,25 @@ public class TestMockEditingContext extends AbstractEditingContextTest {
 
 	editingContext.after();
     }
+
+
+	@Test
+	public void savedObjectUsesGlobalFakeIdInCaseOfALongPK() throws Exception {
+	MockEditingContext editingContext = (MockEditingContext) initEditingContext(TEST_MODEL_NAME);
+
+	editingContext.before();
+
+	LongPKEntity.createLongPKEntity(editingContext);
+
+	editingContext.saveChanges();
+
+	LongPKEntity mockLongPKEntity = editingContext.createSavedObject(LongPKEntity.class);
+
+	assertThat(mockLongPKEntity.valueForKey(mockLongPKEntity.primaryKeyAttributeNames().get(0)), is(2L));
+	assertThat((Long) ((EOKeyGlobalID) mockLongPKEntity.__globalID()).keyValues()[0], is(2L));
+
+	editingContext.after();
+	}
 
     @Before
     public void setup() {

--- a/src/test/resources/Test.eomodeld/LongPKEntity.plist
+++ b/src/test/resources/Test.eomodeld/LongPKEntity.plist
@@ -1,0 +1,14 @@
+{
+    attributes = (
+        {allowsNull = Y; columnName = bar; name = bar; prototypeName = shortString; }, 
+        {allowsNull = N; columnName = id; name = id; prototypeName = longNumber; }, 
+        {allowsNull = Y; columnName = type; name = type; prototypeName = intNumber; }
+    ); 
+    attributesUsedForLocking = (bar, id, type); 
+    className = "com.wounit.model.LongPKEntity"; 
+    classProperties = (bar, type); 
+    externalName = LongPKEntity; 
+    fetchSpecificationDictionary = {}; 
+    name = LongPKEntity; 
+    primaryKeyAttributes = (id); 
+}

--- a/src/test/resources/Test.eomodeld/index.eomodeld
+++ b/src/test/resources/Test.eomodeld/index.eomodeld
@@ -19,6 +19,7 @@
             name = FooEntityWithRequiredField; 
         }, 
         {className = "com.wounit.model.JodaEntity"; name = JodaEntity; }, 
+        {className = "com.wounit.model.LongPKEntity"; name = LongPKEntity; }, 
         {
             className = "com.wounit.model.SubFooEntity"; 
             name = SubFooEntity; 


### PR DESCRIPTION
Currently WOUnit does not support entities that have a primary key of type long.

This small change fixes the issue by using a long global fake id. It takes a look at the type of the PK and casts to long/int as needed.

It would be nice if the fix could be merged in both 1.3 and 1.2.