### PR TITLE
Fix binary incompatibility between Wonder 6 and 7

### DIFF
--- a/src/main/java/com/wounit/rules/MockEditingContext.java
+++ b/src/main/java/com/wounit/rules/MockEditingContext.java
@@ -16,6 +16,8 @@
 
 package com.wounit.rules;
 
+import static com.wounit.rules.WOUnitUtils.arrayMinusArray;
+
 import java.lang.reflect.Field;
 
 import com.webobjects.eoaccess.EOAttribute;
@@ -40,7 +42,6 @@ import com.wounit.annotations.Dummy;
 import er.extensions.eof.ERXModelGroup;
 import er.extensions.eof.ERXQ;
 import er.extensions.eof.ERXS;
-import er.extensions.foundation.ERXArrayUtilities;
 
 /**
  * <code>MockEditingContext</code> is a subclass of
@@ -264,7 +265,7 @@ public class MockEditingContext extends AbstractEditingContextRule {
     @Override
     public NSArray<EOEnterpriseObject> objectsWithFetchSpecification(EOFetchSpecification fetchSpecification, EOEditingContext editingContext) {
 	@SuppressWarnings("unchecked")
-	NSArray<EOEnterpriseObject> availableObjects = ERXArrayUtilities.arrayMinusArray(registeredObjects(), deletedObjects());
+	NSArray<EOEnterpriseObject> availableObjects = arrayMinusArray(registeredObjects(), deletedObjects());
 
 	String entityName = fetchSpecification.entityName();
 
@@ -321,7 +322,7 @@ public class MockEditingContext extends AbstractEditingContextRule {
     @Override
     public void saveChanges() {
 	@SuppressWarnings("unchecked")
-	NSArray<EOEnterpriseObject> insertedObjects = ERXArrayUtilities.arrayMinusArray(insertedObjects(), deletedObjects());
+	NSArray<EOEnterpriseObject> insertedObjects = arrayMinusArray(insertedObjects(), deletedObjects());
 
 	super.saveChanges();
 

--- a/src/main/java/com/wounit/rules/WOUnitUtils.java
+++ b/src/main/java/com/wounit/rules/WOUnitUtils.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2009 hprange <hprange@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.wounit.rules;
+
+import java.util.Enumeration;
+
+import com.webobjects.foundation.NSArray;
+import com.webobjects.foundation.NSMutableArray;
+import com.webobjects.foundation.NSSet;
+
+/**
+ * This class was created to avoid a binary incompatibility between Wonder 6 and
+ * 7 and make WOUnit compatible with both versions.
+ *
+ * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
+ * @since 1.2
+ */
+class WOUnitUtils {
+    /**
+     * Subtracts the contents of one array from another. The order of the array
+     * should be preseved.
+     *
+     * @param main
+     *            array to have values removed from it.
+     * @param minus
+     *            array of values to remove from the main array
+     * @return array after performing subtraction.
+     */
+    static <T> NSArray<T> arrayMinusArray(NSArray<T> main, NSArray<?> minus) {
+	NSSet<Object> minusSet = new NSSet<Object>(minus);
+	NSMutableArray<T> mutableResult = new NSMutableArray<T>(main.count());
+	Enumeration<T> e = main.objectEnumerator();
+
+	while (e.hasMoreElements()) {
+	    T obj = e.nextElement();
+
+	    if (!minusSet.containsObject(obj)) {
+		mutableResult.addObject(obj);
+	    }
+	}
+
+	return mutableResult.immutableClone();
+    }
+
+    private WOUnitUtils() {
+	// Cannot be instantiated
+    }
+}


### PR DESCRIPTION
The signature of some methods of the `ERXArrayUtilities` class is binary incompatible between Wonder 6 and 7. See stack trace below:

```java
java.lang.NoSuchMethodError: er.extensions.foundation.ERXArrayUtilities.arrayMinusArray(Ljava/util/Collection;Ljava/util/Collection;)Lcom/webobjects/foundation/NSArray;
	at com.wounit.rules.MockEditingContext.saveChanges(MockEditingContext.java:324)
```

 Let's inline the incompatible code from Wonder into WOUnit and make everybody happy!