### PR TITLE
Add option to disable partials

### DIFF
--- a/src/main/java/com/wounit/rules/AbstractEditingContextRule.java
+++ b/src/main/java/com/wounit/rules/AbstractEditingContextRule.java
@@ -97,8 +97,11 @@ public abstract class AbstractEditingContextRule extends ERXEC implements Method
     AbstractEditingContextRule(EOObjectStore objectStore, String... modelNames) {
         super(objectStore);
 
+        if (!ERXProperties.hasKey("er.extensions.partials.enabled")) {
+            ERXProperties.setStringForKey("true", "er.extensions.partials.enabled");
+        }
+
         ERXProperties.setStringForKey("true", "NSProjectBundleEnabled");
-        ERXProperties.setStringForKey("true", "er.extensions.partials.enabled");
         ERXProperties.setStringForKey("(" + WOUnitBundleFactory.class.getName() + ")", "NSBundleFactories");
 
         // Simulate what ERExtensions does
@@ -110,7 +113,11 @@ public abstract class AbstractEditingContextRule extends ERXEC implements Method
             loadModel(modelName);
         }
 
-        ERXPartialInitializer.initializer().initializePartialEntities(EOModelGroup.defaultGroup());
+        boolean isPartialsEnabled = ERXProperties.booleanForKey("er.extensions.partials.enabled");
+
+        if (isPartialsEnabled) {
+            ERXPartialInitializer.initializer().initializePartialEntities(EOModelGroup.defaultGroup());
+        }
     }
 
     /**

--- a/src/main/java/com/wounit/rules/AbstractEditingContextRule.java
+++ b/src/main/java/com/wounit/rules/AbstractEditingContextRule.java
@@ -54,7 +54,7 @@ import er.extensions.partials.ERXPartialInitializer;
 public abstract class AbstractEditingContextRule extends ERXEC implements MethodRule {
     // Lazy initialization of singleton instance of ERXExtensions
     private static class SINGLETONS {
-	static ERXExtensions exrExtensions = new ERXExtensions();
+        static ERXExtensions exrExtensions = new ERXExtensions();
     }
 
     /**
@@ -62,21 +62,21 @@ public abstract class AbstractEditingContextRule extends ERXEC implements Method
      * specified editing context.
      */
     static class UnderTestFacade extends EditingContextFacade {
-	public UnderTestFacade(EOEditingContext editingContext) {
-	    super(editingContext);
-	}
+        public UnderTestFacade(EOEditingContext editingContext) {
+            super(editingContext);
+        }
 
-	@Override
-	public EOEnterpriseObject create(Class<? extends EOEnterpriseObject> type) {
-	    EOEntity entity = EOUtilities.entityForClass(editingContext, type);
+        @Override
+        public EOEnterpriseObject create(Class<? extends EOEnterpriseObject> type) {
+            EOEntity entity = EOUtilities.entityForClass(editingContext, type);
 
-	    return EOUtilities.createAndInsertInstance(editingContext, entity.name());
-	}
+            return EOUtilities.createAndInsertInstance(editingContext, entity.name());
+        }
 
-	@Override
-	public void insert(EOEnterpriseObject object) {
-	    editingContext.insertObject(object);
-	}
+        @Override
+        public void insert(EOEnterpriseObject object) {
+            editingContext.insertObject(object);
+        }
     }
 
     private static final long serialVersionUID = 1L;
@@ -95,33 +95,33 @@ public abstract class AbstractEditingContextRule extends ERXEC implements Method
      * Constructor only for test purposes.
      */
     AbstractEditingContextRule(EOObjectStore objectStore, String... modelNames) {
-	super(objectStore);
+        super(objectStore);
 
-	ERXProperties.setStringForKey("true", "NSProjectBundleEnabled");
-	ERXProperties.setStringForKey("true", "er.extensions.partials.enabled");
-	ERXProperties.setStringForKey("(" + WOUnitBundleFactory.class.getName() + ")", "NSBundleFactories");
+        ERXProperties.setStringForKey("true", "NSProjectBundleEnabled");
+        ERXProperties.setStringForKey("true", "er.extensions.partials.enabled");
+        ERXProperties.setStringForKey("(" + WOUnitBundleFactory.class.getName() + ")", "NSBundleFactories");
 
-	// Simulate what ERExtensions does
-	EOModelGroup.setClassDelegate(SINGLETONS.exrExtensions);
-	ERXEntityClassDescription.registerDescription();
-	ERXArrayUtilities.initialize();
+        // Simulate what ERExtensions does
+        EOModelGroup.setClassDelegate(SINGLETONS.exrExtensions);
+        ERXEntityClassDescription.registerDescription();
+        ERXArrayUtilities.initialize();
 
-	for (String modelName : modelNames) {
-	    loadModel(modelName);
-	}
+        for (String modelName : modelNames) {
+            loadModel(modelName);
+        }
 
-	ERXPartialInitializer.initializer().initializePartialEntities(EOModelGroup.defaultGroup());
+        ERXPartialInitializer.initializer().initializePartialEntities(EOModelGroup.defaultGroup());
     }
 
     /**
      * Create a new instance of this editing context loading the models
      * specified by parameter.
-     * 
+     *
      * @param modelNames
      *            the name of the models to be loaded before the test execution.
      */
     public AbstractEditingContextRule(String... modelNames) {
-	this(defaultParentObjectStore(), modelNames);
+        this(defaultParentObjectStore(), modelNames);
     }
 
     /**
@@ -129,48 +129,49 @@ public abstract class AbstractEditingContextRule extends ERXEC implements Method
      * loaded by this class at the beginning of the test execution.
      */
     protected void after() {
-	unlock();
+        unlock();
 
-	try {
-	    dispose();
-	} catch (Exception exception) {
-	    System.out.println("[WARN] An exception has been thrown while disposing the " + getClass().getSimpleName() + " after the test execution.");
+        try {
+            dispose();
+        } catch (Exception exception) {
+            System.out.println("[WARN] An exception has been thrown while disposing the " + getClass().getSimpleName() + " after the test execution.");
 
-	    exception.printStackTrace();
-	}
+            exception.printStackTrace();
+        }
 
-	EOModelGroup modelGroup = EOModelGroup.defaultGroup();
+        EOModelGroup modelGroup = EOModelGroup.defaultGroup();
 
-	for (String modelName : modelToUnload) {
-	    EOModel model = modelGroup.modelNamed(modelName);
+        for (String modelName : modelToUnload) {
+            EOModel model = modelGroup.modelNamed(modelName);
 
-	    modelGroup.removeModel(model);
-	}
+            modelGroup.removeModel(model);
+        }
 
-	ERXEC.setFactory(null);
+        ERXEC.setFactory(null);
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.junit.rules.MethodRule#apply(org.junit.runners.model.Statement,
      * org.junit.runners.model.FrameworkMethod, java.lang.Object)
      */
+    @Override
     public final Statement apply(final Statement base, FrameworkMethod method, final Object target) {
-	processor = new AnnotationProcessor(target);
+        processor = new AnnotationProcessor(target);
 
-	return new Statement() {
-	    @Override
-	    public void evaluate() throws Throwable {
-		before();
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                before();
 
-		try {
-		    base.evaluate();
-		} finally {
-		    after();
-		}
-	    }
-	};
+                try {
+                    base.evaluate();
+                } finally {
+                    after();
+                }
+            }
+        };
     }
 
     /**
@@ -180,16 +181,16 @@ public abstract class AbstractEditingContextRule extends ERXEC implements Method
      * test execution.
      */
     protected void before() {
-	ERXEC.setFactory(new WOUnitEditingContextFactory(this));
+        ERXEC.setFactory(new WOUnitEditingContextFactory(this));
 
-	lock();
+        lock();
 
-	processor.process(UnderTest.class, new UnderTestFacade(this));
+        processor.process(UnderTest.class, new UnderTestFacade(this));
     }
 
     /**
      * Load the model with the specified name into the default model group.
-     * 
+     *
      * @param modelName
      *            name of the model to be loaded
      * @throws IllegalArgumentException
@@ -197,29 +198,29 @@ public abstract class AbstractEditingContextRule extends ERXEC implements Method
      * @see EOModelGroup#defaultGroup
      */
     protected void loadModel(String modelName) {
-	EOModelGroup modelGroup = EOModelGroup.defaultGroup();
+        EOModelGroup modelGroup = EOModelGroup.defaultGroup();
 
-	EOModel model = modelGroup.modelNamed(modelName);
+        EOModel model = modelGroup.modelNamed(modelName);
 
-	if (model != null) {
-	    return;
-	}
+        if (model != null) {
+            return;
+        }
 
-	URL url = getClass().getResource("/Resources/" + modelName + ".eomodeld");
+        URL url = getClass().getResource("/Resources/" + modelName + ".eomodeld");
 
-	if (url == null) {
-	    url = getClass().getResource("/" + modelName + ".eomodeld");
-	}
+        if (url == null) {
+            url = getClass().getResource("/" + modelName + ".eomodeld");
+        }
 
-	if (url == null) {
-	    WOUnitTroubleshooter.diagnoseModelNotFound(modelName);
+        if (url == null) {
+            WOUnitTroubleshooter.diagnoseModelNotFound(modelName);
 
-	    throw new IllegalArgumentException(String.format("Cannot load model named '%s'", modelName));
-	}
+            throw new IllegalArgumentException(String.format("Cannot load model named '%s'", modelName));
+        }
 
-	modelGroup.addModelWithPathURL(url);
+        modelGroup.addModelWithPathURL(url);
 
-	modelToUnload.add(modelName);
+        modelToUnload.add(modelName);
     }
 
 }

--- a/src/test/java/com/wounit/rules/TestPartialEntitiesDisabled.java
+++ b/src/test/java/com/wounit/rules/TestPartialEntitiesDisabled.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2009 hprange <hprange@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.wounit.rules;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.wounit.annotations.UnderTest;
+import com.wounit.model.AugmentedEntity;
+import com.wounit.model.BaseEntity;
+
+import er.extensions.foundation.ERXProperties;
+
+/**
+ * @author <a href="mailto:hprange@gmail.com.br">Henrique Prange</a>
+ */
+public class TestPartialEntitiesDisabled {
+    @BeforeClass
+    public static void disablePartials() {
+        ERXProperties.setStringForKey("false", "er.extensions.partials.enabled");
+    }
+
+    @AfterClass
+    public static void removePartialsConfiguration() {
+        ERXProperties.removeKey("er.extensions.partials.enabled");
+    }
+
+    @UnderTest
+    protected BaseEntity base;
+
+    @Rule
+    public MockEditingContext editingContext = new MockEditingContext("PartialsTest");
+
+    @Test
+    public void disablePartialsAccordingToProperties() throws Exception {
+        try {
+            base.partialForClass(AugmentedEntity.class);
+
+            fail("Must throw an exception when trying to use partials");
+        } catch (Exception exception) {
+            assertThat(exception.getMessage(), containsString("no partial"));
+        }
+    }
+}


### PR DESCRIPTION
Setting the `er.extensions.partials.enabled` property as false causes WOUnit to skip the initialization of partial entities, reducing memory consumption. This option is useful if you don't use partials in your project.