### PR TITLE
Fix error spying EO using recent Mockito version

### DIFF
--- a/src/main/java/com/wounit/rules/AnnotationProcessor.java
+++ b/src/main/java/com/wounit/rules/AnnotationProcessor.java
@@ -42,33 +42,33 @@ import com.wounit.exceptions.WOUnitException;
  */
 class AnnotationProcessor {
     private static EOEnterpriseObject createEOForType(Class<?> type, Class<? extends Annotation> annotation, EditingContextFacade facade) {
-	if (!EOEnterpriseObject.class.isAssignableFrom(type)) {
-	    throw new WOUnitException("Cannot create object of type " + type.getName() + ".\n Only fields and arrays of type " + EOEnterpriseObject.class.getName() + " can be annotated with @" + annotation.getSimpleName() + ".");
-	}
+        if (!EOEnterpriseObject.class.isAssignableFrom(type)) {
+            throw new WOUnitException("Cannot create object of type " + type.getName() + ".\n Only fields and arrays of type " + EOEnterpriseObject.class.getName() + " can be annotated with @" + annotation.getSimpleName() + ".");
+        }
 
-	return facade.create(type.asSubclass(EOEnterpriseObject.class));
+        return facade.create(type.asSubclass(EOEnterpriseObject.class));
     }
 
     private static List<Field> getAllFields(Class<?> type) {
-	List<Field> fields = new ArrayList<Field>();
+        List<Field> fields = new ArrayList<Field>();
 
-	for (Class<?> clazz = type; clazz != null; clazz = clazz.getSuperclass()) {
-	    fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
-	}
+        for (Class<?> clazz = type; clazz != null; clazz = clazz.getSuperclass()) {
+            fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
+        }
 
-	return fields;
+        return fields;
     }
 
     private static int getAnnotationSize(Annotation annotation) {
-	try {
-	    return (Integer) annotation.getClass().getDeclaredMethod("size").invoke(annotation);
-	} catch (Exception exception) {
-	    throw unexpectedException(exception);
-	}
+        try {
+            return (Integer) annotation.getClass().getDeclaredMethod("size").invoke(annotation);
+        } catch (Exception exception) {
+            throw unexpectedException(exception);
+        }
     }
 
     private static WOUnitException unexpectedException(Exception exception) {
-	return new WOUnitException("Something really wrong happened here. Probably a bug.\nPlease, report to http://github.com/hprange/wounit/issues.", exception);
+        return new WOUnitException("Something really wrong happened here. Probably a bug.\nPlease, report to http://github.com/hprange/wounit/issues.", exception);
     }
 
     /**
@@ -88,98 +88,98 @@ class AnnotationProcessor {
 
     /**
      * Create an annotation processor for the given target object.
-     * 
+     *
      * @param target
      *            an object, usually a test case.
      */
     AnnotationProcessor(Object target) {
-	this.target = target;
-	this.fields = getAllFields(target.getClass());
-	this.isMockitoPresent = isMockitoPresent();
+        this.target = target;
+        fields = getAllFields(target.getClass());
+        isMockitoPresent = isMockitoPresent();
     }
 
     private Object initializeObject(Field field, Class<? extends Annotation> annotation, EditingContextFacade facade) {
-	Class<?> type = field.getType();
+        Class<?> type = field.getType();
 
-	int size = getAnnotationSize(field.getAnnotation(annotation));
+        int size = getAnnotationSize(field.getAnnotation(annotation));
 
-	if (NSArray.class.isAssignableFrom(type)) {
-	    Type objectType = field.getGenericType();
+        if (NSArray.class.isAssignableFrom(type)) {
+            Type objectType = field.getGenericType();
 
-	    if (!(objectType instanceof ParameterizedType)) {
-		throw new WOUnitException("Cannot create object for a raw type " + type.getName() + ". Please, provide a generic type.");
-	    }
+            if (!(objectType instanceof ParameterizedType)) {
+                throw new WOUnitException("Cannot create object for a raw type " + type.getName() + ". Please, provide a generic type.");
+            }
 
-	    ParameterizedType genericType = (ParameterizedType) objectType;
+            ParameterizedType genericType = (ParameterizedType) objectType;
 
-	    type = (Class<?>) genericType.getActualTypeArguments()[0];
+            type = (Class<?>) genericType.getActualTypeArguments()[0];
 
-	    NSMutableArray<EOEnterpriseObject> objects = new NSMutableArray<EOEnterpriseObject>();
+            NSMutableArray<EOEnterpriseObject> objects = new NSMutableArray<EOEnterpriseObject>();
 
-	    for (int i = 0; i < size; i++) {
-		EOEnterpriseObject object;
+            for (int i = 0; i < size; i++) {
+                EOEnterpriseObject object;
 
-		if (isMockitoPresent && field.isAnnotationPresent(Spy.class)) {
-		    if (!EOEnterpriseObject.class.isAssignableFrom(type)) {
-			throw new WOUnitException("Cannot create object of type " + type.getName() + ".\n Only fields and arrays of type " + EOEnterpriseObject.class.getName() + " can be annotated with @" + annotation.getSimpleName() + ".");
-		    }
+                if (isMockitoPresent && field.isAnnotationPresent(Spy.class)) {
+                    if (!EOEnterpriseObject.class.isAssignableFrom(type)) {
+                        throw new WOUnitException("Cannot create object of type " + type.getName() + ".\n Only fields and arrays of type " + EOEnterpriseObject.class.getName() + " can be annotated with @" + annotation.getSimpleName() + ".");
+                    }
 
-		    try {
-			object = spy(type.asSubclass(EOEnterpriseObject.class).newInstance());
-		    } catch (Exception exception) {
-			throw unexpectedException(exception);
-		    }
+                    try {
+                        object = spy(type.asSubclass(EOEnterpriseObject.class).newInstance());
+                    } catch (Exception exception) {
+                        throw unexpectedException(exception);
+                    }
 
-		    facade.insert(object);
-		} else {
-		    object = createEOForType(type, annotation, facade);
-		}
+                    facade.insert(object);
+                } else {
+                    object = createEOForType(type, annotation, facade);
+                }
 
-		objects.add(object);
-	    }
+                objects.add(object);
+            }
 
-	    return objects;
-	}
+            return objects;
+        }
 
-	if (size != 1) {
-	    System.out.println("[WARN] The field " + field.getName() + " isn't of NSArray type, but it is annotated with the size property.");
-	}
+        if (size != 1) {
+            System.out.println("[WARN] The field " + field.getName() + " isn't of NSArray type, but it is annotated with the size property.");
+        }
 
-	if (isMockitoPresent && field.isAnnotationPresent(Spy.class)) {
-	    if (!EOEnterpriseObject.class.isAssignableFrom(field.getType())) {
-		throw new WOUnitException("Cannot spy object of type " + field.getType().getName() + ".\n Only fields and arrays of type " + EOEnterpriseObject.class.getName() + " can be annotated with @Spy + @" + annotation.getSimpleName() + ".");
-	    }
+        if (isMockitoPresent && field.isAnnotationPresent(Spy.class)) {
+            if (!EOEnterpriseObject.class.isAssignableFrom(field.getType())) {
+                throw new WOUnitException("Cannot spy object of type " + field.getType().getName() + ".\n Only fields and arrays of type " + EOEnterpriseObject.class.getName() + " can be annotated with @Spy + @" + annotation.getSimpleName() + ".");
+            }
 
-	    field.setAccessible(true);
+            field.setAccessible(true);
 
-	    EOEnterpriseObject object = null;
+            EOEnterpriseObject object = null;
 
-	    try {
-		object = (EOEnterpriseObject) field.get(target);
-	    } catch (Exception exception) {
-		throw unexpectedException(exception);
-	    }
+            try {
+                object = (EOEnterpriseObject) field.get(target);
+            } catch (Exception exception) {
+                throw unexpectedException(exception);
+            }
 
-	    if (object == null) {
-		throw new WOUnitException("The " + field.getName() + " field has not been initialized by Mockito. Make sure the test has been run with MockitoJUnitRunner class.");
-	    }
+            if (object == null) {
+                throw new WOUnitException("The " + field.getName() + " field has not been initialized by Mockito. Make sure the test has been run with MockitoJUnitRunner class.");
+            }
 
-	    facade.insert(object);
+            facade.insert(object);
 
-	    return object;
-	}
+            return object;
+        }
 
-	return createEOForType(type, annotation, facade);
+        return createEOForType(type, annotation, facade);
     }
 
     private boolean isMockitoPresent() {
-	try {
-	    Class.forName("org.mockito.Spy");
-	} catch (ClassNotFoundException exception) {
-	    return false;
-	}
+        try {
+            Class.forName("org.mockito.Spy");
+        } catch (ClassNotFoundException exception) {
+            return false;
+        }
 
-	return true;
+        return true;
     }
 
     /**
@@ -188,29 +188,29 @@ class AnnotationProcessor {
      * <p>
      * Fields annotated with <code>@Spy</code> have their objects inserted in
      * the editing context.
-     * 
+     *
      * @param annotation
      *            the annotation to search for.
      * @param facade
      *            a facade to create and insert enterprise objects.
-     * 
+     *
      * @see org.mockito.Spy
      */
     void process(Class<? extends Annotation> annotation, EditingContextFacade facade) {
-	for (Field field : fields) {
-	    if (!field.isAnnotationPresent(annotation)) {
-		continue;
-	    }
+        for (Field field : fields) {
+            if (!field.isAnnotationPresent(annotation)) {
+                continue;
+            }
 
-	    Object object = initializeObject(field, annotation, facade);
+            Object object = initializeObject(field, annotation, facade);
 
-	    field.setAccessible(true);
+            field.setAccessible(true);
 
-	    try {
-		field.set(target, object);
-	    } catch (Exception exception) {
-		throw unexpectedException(exception);
-	    }
-	}
+            try {
+                field.set(target, object);
+            } catch (Exception exception) {
+                throw unexpectedException(exception);
+            }
+        }
     }
 }

--- a/src/test/java/com/wounit/rules/TestAnnotationProcessor.java
+++ b/src/test/java/com/wounit/rules/TestAnnotationProcessor.java
@@ -60,146 +60,146 @@ public class TestAnnotationProcessor {
 
     @Test
     public void createArrayOfDummiesBasedOnTheGenericType() throws Exception {
-	DummyArrayStubTestCase mockTarget = new DummyArrayStubTestCase();
+        DummyArrayStubTestCase mockTarget = new DummyArrayStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
 
-	assertThat(mockTarget.arrayOfOneDummy().get(0), instanceOf(FooEntity.class));
+        assertThat(mockTarget.arrayOfOneDummy().get(0), instanceOf(FooEntity.class));
     }
 
     @Test
     public void createArrayOfDummiesIfAnnotationAndSizePresent() throws Exception {
-	DummyArrayStubTestCase mockTarget = new DummyArrayStubTestCase();
+        DummyArrayStubTestCase mockTarget = new DummyArrayStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
 
-	assertThat(mockTarget.arrayOfTwoDummies().size(), is(2));
+        assertThat(mockTarget.arrayOfTwoDummies().size(), is(2));
     }
 
     @Test
     public void createArrayOfOneDummyIfAnnotationPresentButNoSize() throws Exception {
-	DummyArrayStubTestCase mockTarget = new DummyArrayStubTestCase();
+        DummyArrayStubTestCase mockTarget = new DummyArrayStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
 
-	assertThat(mockTarget.arrayOfOneDummy(), notNullValue());
-	assertThat(mockTarget.arrayOfOneDummy().size(), is(1));
+        assertThat(mockTarget.arrayOfOneDummy(), notNullValue());
+        assertThat(mockTarget.arrayOfOneDummy().size(), is(1));
     }
 
     @Test
     public void createObjectForInheritedFieldIfAnnotationPresent() throws Exception {
-	ChildStubTestCase mockTarget = new ChildStubTestCase();
+        ChildStubTestCase mockTarget = new ChildStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
 
-	assertThat(mockTarget.foo(), is(mockFoo));
+        assertThat(mockTarget.foo(), is(mockFoo));
     }
 
     @Test
     public void createObjectIfAnnotationPresent() throws Exception {
-	StubTestCase mockTarget = new StubTestCase();
+        StubTestCase mockTarget = new StubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
 
-	assertThat(mockTarget.foo(), is(mockFoo));
+        assertThat(mockTarget.foo(), is(mockFoo));
     }
 
     @Test
     public void doNotCreateObjectIfAnnotationIsAbsent() throws Exception {
-	StubTestCase mockTarget = new StubTestCase();
+        StubTestCase mockTarget = new StubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
 
-	assertThat(mockTarget.objectUnderTest(), nullValue());
+        assertThat(mockTarget.objectUnderTest(), nullValue());
     }
 
     @Test
     public void exceptionIfAnnotatedGenericTypeIsIncompatible() throws Exception {
-	WrongGenericTypeForDummyStubTestCase mockTarget = new WrongGenericTypeForDummyStubTestCase();
+        WrongGenericTypeForDummyStubTestCase mockTarget = new WrongGenericTypeForDummyStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	thrown.expect(WOUnitException.class);
-	thrown.expectMessage(is("Cannot create object of type java.lang.String.\n Only fields and arrays of type com.webobjects.eocontrol.EOEnterpriseObject can be annotated with @Dummy."));
+        thrown.expect(WOUnitException.class);
+        thrown.expectMessage(is("Cannot create object of type java.lang.String.\n Only fields and arrays of type com.webobjects.eocontrol.EOEnterpriseObject can be annotated with @Dummy."));
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
     }
 
     @Test
     public void exceptionIfAnnotatedTypeIsIncompatible() throws Exception {
-	WrongTypeForDummyStubTestCase mockTarget = new WrongTypeForDummyStubTestCase();
+        WrongTypeForDummyStubTestCase mockTarget = new WrongTypeForDummyStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	thrown.expect(WOUnitException.class);
-	thrown.expectMessage(is("Cannot create object of type java.lang.String.\n Only fields and arrays of type com.webobjects.eocontrol.EOEnterpriseObject can be annotated with @Dummy."));
+        thrown.expect(WOUnitException.class);
+        thrown.expectMessage(is("Cannot create object of type java.lang.String.\n Only fields and arrays of type com.webobjects.eocontrol.EOEnterpriseObject can be annotated with @Dummy."));
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
     }
 
     @Test
     public void exceptionIfRawArrayAnnotated() throws Exception {
-	RawArrayDeclarationForDummyStubTestCase mockTarget = new RawArrayDeclarationForDummyStubTestCase();
+        RawArrayDeclarationForDummyStubTestCase mockTarget = new RawArrayDeclarationForDummyStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	thrown.expect(WOUnitException.class);
-	thrown.expectMessage(is("Cannot create object for a raw type com.webobjects.foundation.NSArray. Please, provide a generic type."));
+        thrown.expect(WOUnitException.class);
+        thrown.expectMessage(is("Cannot create object for a raw type com.webobjects.foundation.NSArray. Please, provide a generic type."));
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
     }
 
     @Test
     public void exceptionIfSpiedGenericTypeIsIncompatible() throws Exception {
-	WrongGenericTypeForSpiedObjectStubTestCase mockTarget = new WrongGenericTypeForSpiedObjectStubTestCase();
+        WrongGenericTypeForSpiedObjectStubTestCase mockTarget = new WrongGenericTypeForSpiedObjectStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	thrown.expect(WOUnitException.class);
-	thrown.expectMessage(is("Cannot create object of type java.lang.String.\n Only fields and arrays of type com.webobjects.eocontrol.EOEnterpriseObject can be annotated with @Dummy."));
+        thrown.expect(WOUnitException.class);
+        thrown.expectMessage(is("Cannot create object of type java.lang.String.\n Only fields and arrays of type com.webobjects.eocontrol.EOEnterpriseObject can be annotated with @Dummy."));
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
     }
 
     @Test
     public void exceptionIfSpiedObjectNotInitialied() throws Exception {
-	NotInitializedSpiedObjectStubTestCase mockTarget = new NotInitializedSpiedObjectStubTestCase();
+        NotInitializedSpiedObjectStubTestCase mockTarget = new NotInitializedSpiedObjectStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	thrown.expect(WOUnitException.class);
-	thrown.expectMessage(is("The value field has not been initialized by Mockito. Make sure the test has been run with MockitoJUnitRunner class."));
+        thrown.expect(WOUnitException.class);
+        thrown.expectMessage(is("The value field has not been initialized by Mockito. Make sure the test has been run with MockitoJUnitRunner class."));
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
     }
 
     @Test
     public void exceptionIfSpyingIncompatibleType() throws Exception {
-	WrongTypeForSpiedObjectStubTestCase mockTarget = new WrongTypeForSpiedObjectStubTestCase();
+        WrongTypeForSpiedObjectStubTestCase mockTarget = new WrongTypeForSpiedObjectStubTestCase();
 
-	AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
+        AnnotationProcessor processor = new AnnotationProcessor(mockTarget);
 
-	thrown.expect(WOUnitException.class);
-	thrown.expectMessage(is("Cannot spy object of type java.lang.String.\n Only fields and arrays of type com.webobjects.eocontrol.EOEnterpriseObject can be annotated with @Spy + @Dummy."));
+        thrown.expect(WOUnitException.class);
+        thrown.expectMessage(is("Cannot spy object of type java.lang.String.\n Only fields and arrays of type com.webobjects.eocontrol.EOEnterpriseObject can be annotated with @Spy + @Dummy."));
 
-	processor.process(Dummy.class, mockFacade);
+        processor.process(Dummy.class, mockFacade);
     }
 
     @Before
     @SuppressWarnings("unchecked")
     public void setup() {
-	when(mockFacade.create(Mockito.any(Class.class))).thenReturn(mockFoo);
+        when(mockFacade.create(Mockito.any(Class.class))).thenReturn(mockFoo);
     }
 }

--- a/src/test/java/com/wounit/stubs/NotInitializedSpiedObjectStubTestCase.java
+++ b/src/test/java/com/wounit/stubs/NotInitializedSpiedObjectStubTestCase.java
@@ -26,5 +26,9 @@ import com.wounit.model.FooEntity;
 public class NotInitializedSpiedObjectStubTestCase {
     @Spy
     @Dummy
-    public FooEntity value = null;
+    private FooEntity value;
+
+    public FooEntity value() {
+        return value;
+    }
 }


### PR DESCRIPTION
Depending on the Mockito version, the MockitoJUnitRunner evaluation may not run before evaluating the WOUnit rule. As a result, fields annotated with `@Spy` may be null at WOUnit initialization. This fix creates and spies objects preventing an error.