### PR TITLE
Add a hasValueForKey matcher to EOAssert

### DIFF
--- a/src/main/java/com/wounit/matchers/EOAssert.java
+++ b/src/main/java/com/wounit/matchers/EOAssert.java
@@ -116,8 +116,10 @@ import static org.hamcrest.CoreMatchers.not;
  * // Safer check whether the editing context does not save changes successfully
  * confirm(editingContext, doNotSaveChangesBecause(&quot;The bar property of Foo cannot be null&quot;));
  * </pre>
+ *
+ * <b>Check if a value matches an expression using key-value coding</b>
  * <p>
- * The {@code EOAssert} class provides static methods to check where a value matches an expression
+ * The {@code EOAssert} class provides static methods to check if a value matches an expression
  * using the key-value coding mechanism.
  * <pre>
  * // Checks whether a value matches an expression using the key-value coding mechanism

--- a/src/main/java/com/wounit/matchers/EOAssert.java
+++ b/src/main/java/com/wounit/matchers/EOAssert.java
@@ -13,17 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.wounit.matchers;
 
-import static org.hamcrest.CoreMatchers.not;
-
+import com.webobjects.eocontrol.EOEditingContext;
+import com.webobjects.eocontrol.EOEnterpriseObject;
+import er.extensions.eof.ERXKey;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 
-import com.webobjects.eocontrol.EOEditingContext;
-import com.webobjects.eocontrol.EOEnterpriseObject;
+import static org.hamcrest.CoreMatchers.not;
 
 /**
  * This class is the entry point for writing assertions to WebObjects related
@@ -117,7 +116,19 @@ import com.webobjects.eocontrol.EOEnterpriseObject;
  * // Safer check whether the editing context does not save changes successfully
  * confirm(editingContext, doNotSaveChangesBecause(&quot;The bar property of Foo cannot be null&quot;));
  * </pre>
- * 
+ * <p>
+ * The {@code EOAssert} class provides static methods to check where a value matches an expression
+ * using the key-value coding mechanism.
+ * <pre>
+ * // Checks whether a value matches an expression using the key-value coding mechanism
+ * assertThat(fooEntity, hasValueForKey(FooEntity.BAR_KEY, is("a value")));
+ * </pre>
+ *
+ * <pre>
+ *  // Checks whether an NSArray contains an item whose value matches an expression using the key-value coding mechanism
+ *  assertThat(arrayOfFoos, hasItem(hasValueForKey(FooEntity.BAR_KEY, is("a value"))));
+ *  </pre>
+ *
  * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
  * @since 1.0
  * @see org.junit.Assert
@@ -334,6 +345,30 @@ public class EOAssert {
      */
     public static Matcher<EOEditingContext> saveChanges() {
 	return new SaveChangesMatcher<EOEditingContext>();
+    }
+
+    /**
+     * Used to check whether a value matches an expression using the key-value coding mechanism.
+     *
+     * @param key          identifies the property to retrieve
+     * @param valueMatcher a matcher for the value obtained using the key of the examined object
+     * @return a <code>Matcher</code> matching if the value matches an expression using the key-value
+     * coding mechanism.
+     */
+    public static <T> Matcher<T> hasValueForKey(String key, Matcher<?> valueMatcher) {
+        return HasValueForKeyMatcher.hasValueForKey(key, valueMatcher);
+    }
+
+    /**
+     * Used to check whether a value matches an expression using the key-value coding mechanism.
+     *
+     * @param key          identifies the property to retrieve
+     * @param valueMatcher a matcher for the value obtained using the key of the examined object
+     * @return a <code>Matcher</code> matching if the value matches an expression using the key-value
+     * coding mechanism.
+     */
+    public static <T, V> Matcher<T> hasValueForKey(ERXKey<V> key, Matcher<V> valueMatcher) {
+        return HasValueForKeyMatcher.hasValueForKey(key.key(), valueMatcher);
     }
 
     /**

--- a/src/main/java/com/wounit/matchers/HasValueForKeyMatcher.java
+++ b/src/main/java/com/wounit/matchers/HasValueForKeyMatcher.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2009 hprange <hprange@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.wounit.matchers;
+
+import com.webobjects.foundation.NSKeyValueCodingAdditions;
+import org.hamcrest.Condition;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static org.hamcrest.Condition.matched;
+import static org.hamcrest.Condition.notMatched;
+
+/**
+ * Matcher that asserts that a value obtained via the key-value mechanism meets the provided matcher.
+ *
+ * @param <T> the type of the object being checked
+ * @author <a href="mailto:hprange@gmail.com">Henrique Prange</a>
+ * @since 1.5
+ */
+class HasValueForKeyMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
+    public static <T> Matcher<T> hasValueForKey(String key, Matcher<?> valueMatcher) {
+        return new HasValueForKeyMatcher<>(key, valueMatcher);
+    }
+
+    private final String key;
+    private final Matcher<?> valueMatcher;
+
+    public HasValueForKeyMatcher(String key, Matcher<?> valueMatcher) {
+        this.key = key;
+        this.valueMatcher = valueMatcher;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected boolean matchesSafely(T object, Description mismatch) {
+        return hasKeyOn(object, mismatch)
+                .and(hasValueForKey(object))
+                .matching((Matcher<Object>) valueMatcher);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("hasValueForKey(")
+                .appendValue(key)
+                .appendText(", ")
+                .appendDescriptionOf(valueMatcher)
+                .appendText(")");
+    }
+
+    private Condition<String> hasKeyOn(T object, Description mismatch) {
+        if (key == null) {
+            mismatch.appendText("No value for null key");
+            return notMatched();
+        }
+
+        try {
+            NSKeyValueCodingAdditions.Utility.valueForKeyPath(object, key);
+            return matched(key, mismatch);
+        } catch (Exception exception) {
+            mismatch.appendText(exception.getMessage());
+            return notMatched();
+        }
+    }
+
+    private Condition.Step<String, Object> hasValueForKey(Object object) {
+        return (key, mismatch) -> matched(NSKeyValueCodingAdditions.Utility.valueForKeyPath(object, key), mismatch);
+    }
+}

--- a/src/test/java/com/wounit/matchers/TestHasValueForKeyMatcher.java
+++ b/src/test/java/com/wounit/matchers/TestHasValueForKeyMatcher.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2009 hprange <hprange@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.wounit.matchers;
+
+import com.webobjects.foundation.NSArray;
+import com.webobjects.foundation.NSMutableArray;
+import com.wounit.annotations.Dummy;
+import com.wounit.model.FooEntity;
+import com.wounit.model.FooEntityWithRequiredField;
+import com.wounit.rules.MockEditingContext;
+import er.extensions.eof.ERXKey;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static com.wounit.matchers.EOAssert.hasValueForKey;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestHasValueForKeyMatcher {
+    @Rule
+    public final MockEditingContext editingContext = new MockEditingContext("Test");
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Dummy
+    FooEntity foo;
+
+    @Dummy
+    FooEntityWithRequiredField relatedFoo;
+
+    NSArray<FooEntity> foos;
+
+    @Before
+    public void setup() {
+        thrown.handleAssertionErrors();
+
+        foo.setBar("sample");
+
+        foos = new NSMutableArray<>();
+        foos.add(foo);
+
+        relatedFoo.setFooEntityRelationship(foo);
+    }
+
+    @Test
+    public void hasValueForKeySuccess() {
+        assertThat(foo, hasValueForKey(FooEntity.BAR_KEY, is("sample")));
+    }
+
+    @Test
+    public void hasValueForKeyWhenValueIsWrong() {
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage(is("\nExpected: hasValueForKey(\"bar\", is \"wrong\")\n     but: was \"sample\""));
+
+        assertThat(foo, hasValueForKey(FooEntity.BAR_KEY, is("wrong")));
+    }
+
+    @Test
+    public void hasValueForKeyInArray() {
+        assertThat(foos, hasItem(hasValueForKey(FooEntity.BAR_KEY, is("sample"))));
+    }
+
+    @Test
+    public void hasValueForKeyInEmptyArray() {
+        foos.clear();
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage(is("\nExpected: a collection containing hasValueForKey(\"bar\", is \"sample\")\n     but: "));
+
+        assertThat(foos, hasItem(hasValueForKey(FooEntity.BAR_KEY, is("sample"))));
+    }
+
+    @Test
+    public void hasValueForKeyInArrayWithWrongValue() {
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage(is("\nExpected: a collection containing hasValueForKey(\"bar\", is \"wrong\")\n     but: was \"sample\""));
+
+        assertThat(foos, hasItem(hasValueForKey(FooEntity.BAR_KEY, is("wrong"))));
+    }
+
+    @Test
+    public void hasValueForKeyWhenKeyDoesNotExist() {
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage(both(startsWith("\nExpected: hasValueForKey(\"unknown\", is \"sample\")\n     but: <com.wounit.model.FooEntity"))
+                .and(endsWith("valueForKey(): lookup of unknown key: 'unknown'.\nThis class does not have an instance variable of the name unknown or _unknown, nor a method of the name unknown, _unknown, getUnknown, or _getUnknown")));
+
+        assertThat(foo, hasValueForKey("unknown", is("sample")));
+    }
+
+    @Test
+    public void hasValueForKeyPath() {
+        String keypath = FooEntityWithRequiredField.FOO_ENTITY_KEY + "." + FooEntity.BAR_KEY;
+
+        assertThat(relatedFoo, hasValueForKey(keypath, is("sample")));
+    }
+
+    @Test
+    public void hasValueForKeyWhenKeyPathDoesNotExist() {
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage(both(startsWith("\nExpected: hasValueForKey(\"fooEntity.unknown\", is \"sample\")\n     but: <com.wounit.model.FooEntity"))
+                .and(endsWith("valueForKey(): lookup of unknown key: 'unknown'.\nThis class does not have an instance variable of the name unknown or _unknown, nor a method of the name unknown, _unknown, getUnknown, or _getUnknown")));
+
+        String keypath = FooEntityWithRequiredField.FOO_ENTITY_KEY + ".unknown";
+
+        assertThat(relatedFoo, hasValueForKey(keypath, is("sample")));
+    }
+
+    @Test
+    public void hasValueForKeyWhenObjectIsNull() {
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage(is("\nExpected: hasValueForKey(\"bar\", is \"sample\")\n     but: was null"));
+
+        assertThat(null, hasValueForKey(FooEntity.BAR_KEY, is("sample")));
+    }
+
+    @Test
+    public void hasValueForKeyWhenKeyIsNull() {
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage(is("\nExpected: hasValueForKey(null, is \"sample\")\n     but: No value for null key"));
+
+        assertThat(foo, hasValueForKey((String) null, is("sample")));
+    }
+
+    @Test
+    public void hasValueForKeyWhenValueIsNull() {
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage(is("\nExpected: hasValueForKey(\"bar\", is null)\n     but: was \"sample\""));
+
+        assertThat(foo, hasValueForKey(FooEntity.BAR_KEY, is((String) null)));
+    }
+
+    @Test
+    public void hasValueForKeyWithERXKey() {
+        ERXKey<String> key = new ERXKey<>(FooEntity.BAR_KEY);
+
+        assertThat(foo, hasValueForKey(key, is("sample")));
+    }
+
+    @Test
+    public void hasValueForKeyPathWithERXKey() {
+        ERXKey<String> keypath = new ERXKey<>(FooEntityWithRequiredField.FOO_ENTITY_KEY).dot(new ERXKey<>(FooEntity.BAR_KEY));
+
+        assertThat(relatedFoo, hasValueForKey(keypath, is("sample")));
+    }
+}


### PR DESCRIPTION
The `hasValueForKey` matcher asserts that a value obtained via the key-value mechanism meets the provided matcher.